### PR TITLE
plist_options deprecation

### DIFF
--- a/Formula/dynamodb-local.rb
+++ b/Formula/dynamodb-local.rb
@@ -60,7 +60,7 @@ class DynamodbLocal < Formula
     EOS
   end
 
-  plist_options :manual => "#{HOMEBREW_PREFIX}/bin/dynamodb-local"
+  service.require_root :manual => "#{HOMEBREW_PREFIX}/bin/dynamodb-local"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/elasticmq.rb
+++ b/Formula/elasticmq.rb
@@ -21,7 +21,7 @@ class Elasticmq < Formula
     bin.install libexec/"bin/elasticmq"
   end
 
-  plist_options :manual => "elasticmq"
+  service.require_root :manual => "elasticmq"
 
   def plist; <<~EOS
       <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
```
Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the boltapp/public tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/boltapp/homebrew-public/Formula/elasticmq.rb:24

Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the boltapp/public tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/boltapp/homebrew-public/Formula/dynamodb-local.rb:63
```